### PR TITLE
Link DOIs to preferred resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ to add something please make a pull request or open an issue.
 If you find the scRNA-tools database useful for your work please cite our
 preprint: "Zappia L, Phipson B, Oshlack A. [Exploring the single-cell RNA-seq
 analysis landscape with the scRNA-tools
-database](http://dx.doi.org/10.1101/206573), bioRxiv (2017), DOI: 10.1101/206573"
+database](https://doi.org/10.1101/206573), bioRxiv (2017), DOI: 10.1101/206573"
 
 ## Structure
 

--- a/docs/data/faqs.json
+++ b/docs/data/faqs.json
@@ -27,6 +27,6 @@
   {
     "id": "FAQ6",
     "question": "How can I cite scRNA-tools.org?",
-    "answer": "If you find the scRNA-tools database useful for your work please cite our preprint: \"Zappia L, Phipson B, Oshlack A. <a href=\"http://dx.doi.org/10.1101/206573\">Exploring the single-cell RNA-seq analysis landscape with the scRNA-tools database</a>, bioRxiv (2017), DOI: 10.1101/206573\""
+    "answer": "If you find the scRNA-tools database useful for your work please cite our preprint: \"Zappia L, Phipson B, Oshlack A. <a href=\"https://doi.org/10.1101/206573\">Exploring the single-cell RNA-seq analysis landscape with the scRNA-tools database</a>, bioRxiv (2017), DOI: 10.1101/206573\""
   }
 ]

--- a/docs/js/jquery-tools.js
+++ b/docs/js/jquery-tools.js
@@ -158,7 +158,7 @@ $(document).ready(function () {
               var id = doi.replace("arxiv/", "")
               entry += '<strong>arXiv: </strong> <a href="https://arxiv.org/abs/' + id + '">' + id + '</a>'
             } else {
-              entry += '<strong>DOI: </strong> <a href="http://dx.doi.org/' + doi + '">' + doi + '</a>'
+              entry += '<strong>DOI: </strong> <a href="https://doi.org/' + doi + '">' + doi + '</a>'
             }
             if (isPre == true) {
               entry += ', <strong>Preprint</strong>'

--- a/process_csv.R
+++ b/process_csv.R
@@ -181,7 +181,7 @@ fix_doi <- function(swsheet) {
         mutate(PubDates = as_date(PubDates)) %>%
         mutate(Preprint = ifelse(Preprint == TRUE, TRUE, NA)) %>%
         mutate(DOIURL = ifelse(is.na(DOI), NA,
-                               paste0('http://dx.doi.org/', DOI)))
+                               paste0('https://doi.org/', DOI)))
 }
 
 


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates static DOI links and the code that generates new ones.

Cheers!